### PR TITLE
Replaced 7za.exe with 7z.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Explicitly *excluding* a single VM will still run backups for all other VMs. Exp
 ```
 [ --compress ]  [ -1 - 9 ]
 ```
-***!!!*** In order to enable data compression you need to install [7-Zip](https://www.7-zip.org/) and [7-Zip Extra](https://www.7-zip.org/). To disable compression, leave this parameter out or explicitly set it to `-1`.
+***!!!*** In order to enable data compression you need to install [7-Zip](https://www.7-zip.org/) to the default path `C:\Program Files\7-Zip\7z.exe`. To disable compression, leave this parameter out or explicitly set it to `-1`.
 
 The VM Backup Files can be compressed to a single 7-Zip file to save some diskspace and to make them easier to move around.
 

--- a/VirtualBox Backup.bat
+++ b/VirtualBox Backup.bat
@@ -11,7 +11,7 @@ CLS
 	FOR %%L IN ("%~dp0.") DO SET "_LOGFILE=%%~fL\log.txt"
 
 	SET "_VBOXMANAGE=C:\Program Files\Oracle\VirtualBox\VBoxManage.exe"
-	SET "_7za=C:\Program Files\7-Zip\7za.exe"
+	SET "_7z=C:\Program Files\7-Zip\7z.exe"
 	SET "_DATE=%_DATETIME:~0,4%.%_DATETIME:~4,2%.%_DATETIME:~6,2%"
 	SET "_TIME=%_DATETIME:~8,2%.%_DATETIME:~10,2%"
 	SET "_ERROR=0"
@@ -59,7 +59,7 @@ CLS
 
 	IF %_COMPRESS% GEQ 0 (
 		IF %_COMPRESS% LEQ 9 (
-			IF EXIST "%_7za%" (
+			IF EXIST "%_7z%" (
 				SET "_COMPRESSENABLED=TRUE"
 			)
 		)
@@ -208,7 +208,7 @@ CLS
 	:: Compress
 		IF DEFINED _COMPRESSENABLED (
 			CALL :DebugLog "Compressing..."
-			"%_7za%" a -mx%_COMPRESS% -sdel "%_BACKUPDIR%\%_VM_Name%\%_VMBACKUPNAME%.7z" "%TEMP%\%_VM_UUID%\*"
+			"%_7z%" a -mx%_COMPRESS% -sdel "%_BACKUPDIR%\%_VM_Name%\%_VMBACKUPNAME%.7z" "%TEMP%\%_VM_UUID%\*"
 		) ELSE (
 			IF /I NOT "%_BACKUPDIR%"=="false" (
 				CALL :DebugLog "Moving..."


### PR DESCRIPTION
7za.exe was used because 7z.exe did not support CLI operations. This is no longer required.